### PR TITLE
feat(home): ajout du filtrage réactif des tâches par statut Closes #4

### DIFF
--- a/app/Models/Todos.php
+++ b/app/Models/Todos.php
@@ -13,7 +13,8 @@ class Todos extends Model
     use HasFactory;
     use SoftDeletes;
 
-    protected $fillable = ['texte', 'termine', 'important'];
+    // Champs autorisés pour l'assignation de masse (Mass Assignment)
+    protected $fillable = ['texte', 'termine', 'important', 'user_id'];
 
     // Optionnel mais recommandé si tu veux accéder à deleted_at comme un objet Carbon
     // protected $dates = ['deleted_at'];

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -24,3 +24,12 @@
 .border-custom-dark {
   border: 1px solid $dark !important;
 }
+
+/* Ajout de transitions fluides pour améliorer l'expérience utilisateur */
+.btn {
+    transition: all 0.3s ease;
+}
+
+.list-group-item {
+    transition: all 0.2s ease;
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -48,10 +48,36 @@
                 </div>
             </form>
 
-            <!-- Liste -->
-            <ul class="list-group">
+            <!-- Liste de tâches avec filtrage réactif via Alpine.js -->
+            <!-- La variable 'filter' est persistée dans le localStorage pour rester active après un rechargement -->
+            <div x-data="{ filter: localStorage.getItem('todo_filter') || 'all' }" 
+                 x-init="$watch('filter', val => localStorage.setItem('todo_filter', val))">
+                <!-- Boutons de filtre : Toutes / En cours / Terminées -->
+                <div class="mb-4 d-flex justify-content-center">
+                    <div class="btn-group" role="group" aria-label="Filtrage des tâches">
+                        <button type="button" class="btn px-4" 
+                                :class="filter === 'all' ? 'btn-primary shadow-sm' : 'btn-outline-primary'"
+                                @click="filter = 'all'">
+                            <i class="bi bi-list-task me-1"></i> Toutes
+                        </button>
+                        <button type="button" class="btn px-4" 
+                                :class="filter === 'active' ? 'btn-primary shadow-sm' : 'btn-outline-primary'"
+                                @click="filter = 'active'">
+                            <i class="bi bi-clock-history me-1"></i> En cours
+                        </button>
+                        <button type="button" class="btn px-4" 
+                                :class="filter === 'completed' ? 'btn-primary shadow-sm' : 'btn-outline-primary'"
+                                @click="filter = 'completed'">
+                            <i class="bi bi-check-all me-1"></i> Terminées
+                        </button>
+                    </div>
+                </div>
+
+                <ul class="list-group">
                 @forelse ($todos as $todo)
-                    <li class="list-group-item">
+                    <!-- Affichage conditionnel de chaque tâche en fonction du filtre actif -->
+                    <li class="list-group-item" 
+                        x-show="filter === 'all' || (filter === 'active' && {{ $todo->termine }} === 0) || (filter === 'completed' && {{ $todo->termine }} === 1)">
                         <!-- Affichage de la priorité -->
                         @if ($todo->important == 0)
                             <i class="bi bi-reception-1"></i>
@@ -111,7 +137,8 @@
                 @empty
                     <li class="list-group-item text-center">C'est vide !</li>
                 @endforelse
-            </ul>
+                </ul>
+            </div>
         </div>
     </div>
 </div>

--- a/tests/Feature/TodoFilterTest.php
+++ b/tests/Feature/TodoFilterTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Todos;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TodoFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Vérifie que les boutons de filtre (Toutes, En cours, Terminées) sont bien affichés.
+     */
+    public function test_les_filtres_sont_presents_sur_la_page_accueil()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSee('Toutes');
+        $response->assertSee('En cours');
+        $response->assertSee('Terminées');
+    }
+
+    /**
+     * Vérifie que les tâches avec différents statuts sont bien chargées
+     * et que les directives Alpine.js pour le filtrage sont présentes.
+     */
+    public function test_les_taches_sont_affichees_et_peuvent_etre_filtrees_reactivement()
+    {
+        $user = User::factory()->create();
+
+        $todoEnCours = Todos::create([
+            'texte' => 'Tâche en cours',
+            'termine' => 0,
+            'user_id' => $user->id,
+        ]);
+
+        $todoTerminee = Todos::create([
+            'texte' => 'Tâche terminée',
+            'termine' => 1,
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSee('Tâche en cours');
+        $response->assertSee('Tâche terminée');
+
+        // On vérifie que les éléments Alpine.js sont là
+        $response->assertSee('x-data');
+        $response->assertSee('x-show');
+    }
+}


### PR DESCRIPTION
## User story
En tant qu'utilisateur, je veux filtrer mes tâches par statut
afin de me concentrer sur ce qui est en cours.

## Critères d'acceptation

- [x] 3 boutons de filtre : Toutes / En cours / Terminées
- [x] Le filtre est réactif (sans rechargement de page)
- [x] L'état du filtre actif est visuellement indiqué
- [x] Tests Feature ajoutés

Closes #4